### PR TITLE
Correct case of library header file in example

### DIFF
--- a/examples/ultrasonic.ino
+++ b/examples/ultrasonic.ino
@@ -1,4 +1,4 @@
-#include "ultrasonic.h"
+#include "Ultrasonic.h"
 
 #define TRIG_PIN 5
 #define ECHO_PIN 6


### PR DESCRIPTION
The incorrect capitalization of the file Ultrasonic.h in the example sketch's `#include` directive caused compilation to fail:
```
E:\electronics\arduino\libraries\HC-SR04-master\examples\ultrasonic\ultrasonic.ino:1:24: fatal error: ultrasonic.h: No such file or directory

 #include "ultrasonic.h"
```